### PR TITLE
Changed to map over results instead of errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,12 @@ function tapLesshint (action) {
 }
 
 function toJshint (file) {
-	return file.lesshint.errors.map(function (error) {
+	return file.lesshint.results.map(function (error) {
 		return {
 			file: file.base + error.file,
 			error: {
 				character: error.column,
-				code: 'W ' + error.linter,
+				code: error.severity + ' ' + error.linter,
 				line: error.line,
 				reason: error.message
 			}


### PR DESCRIPTION
file.lesshint.errors has been replaced with file.lesshint.results by the look of it, fixing this allows this reporter to be used again, otherwise it errors out

also added in severity instead of just the hardcoded 'W ' for error.code
